### PR TITLE
Use Amazon Athena SDK functions for prepared statements instead of using SQL queries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (c) 2017 Segment.io, Inc.
 Copyright (c) 2020 Speee, Inc.
+Copyright (c) 2025 BaseMachina, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 **This is forked from [speee/go-athena](https://github.com/speee/go-athena).**
 
+The following are the main changes that have been made:
+
+## Changes
+
+- Use Amazon Athena SDK functions for prepared statements instead of using SQL queries.
+
 ---
 
 [![](https://godoc.org/github.com/speee/go-athena?status.svg)](https://godoc.org/github.com/speee/go-athena)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go-athena is a simple Golang [database/sql] driver for [Amazon Athena](https://a
 ```go
 import (
     "database/sql"
-    _ "github.com/speee/go-athena"
+    _ "github.com/basemachina/go-athena"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**This is forked from [speee/go-athena](https://github.com/speee/go-athena).**
+
+---
+
 [![](https://godoc.org/github.com/speee/go-athena?status.svg)](https://godoc.org/github.com/speee/go-athena)
 
 **This is forked from [segmentio/go-athena](https://github.com/segmentio/go-athena) and we described what changes we added [here](./doc/introduction.md).**

--- a/conn.go
+++ b/conn.go
@@ -227,14 +227,12 @@ func (c *conn) prepareContext(ctx context.Context, query string) (driver.Stmt, e
 
 	// prepare
 	prepareKey := fmt.Sprintf("tmp_prepare_%v", strings.Replace(uuid.NewV4().String(), "-", "", -1))
-	newQuery := fmt.Sprintf("PREPARE %s FROM %s", prepareKey, query)
-
-	queryID, err := c.startQuery(newQuery)
+	_, err := c.athena.CreatePreparedStatement(&athena.CreatePreparedStatementInput{
+		StatementName:  aws.String(prepareKey),
+		WorkGroup:      aws.String(c.workgroup),
+		QueryStatement: aws.String(query),
+	})
 	if err != nil {
-		return nil, err
-	}
-
-	if err := c.waitOnQuery(ctx, queryID); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/speee/go-athena
+module github.com/basemachina/go-athena
 
 go 1.14
 

--- a/stmt.go
+++ b/stmt.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/prestodb/presto-go-client/presto"
 )
 
@@ -20,8 +22,10 @@ type stmtAthena struct {
 }
 
 func (s *stmtAthena) Close() error {
-	query := fmt.Sprintf("DEALLOCATE PREPARE %s", s.prepareKey)
-	_, err := s.conn.startQuery(query)
+	_, err := s.conn.athena.DeletePreparedStatement(&athena.DeletePreparedStatementInput{
+		StatementName: aws.String(s.prepareKey),
+		WorkGroup:     aws.String(s.conn.workgroup),
+	})
 	return err
 }
 


### PR DESCRIPTION
Use Amazon Athena SDK functions for creating and deleting prepared statements instead of using SQL queries.