### PR TITLE
Return unknown row value as bytes

### DIFF
--- a/value.go
+++ b/value.go
@@ -109,6 +109,6 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 	case "date":
 		return time.Parse(DateLayout, val)
 	default:
-		panic(fmt.Errorf("unknown type `%s` with value %s", athenaType, val))
+		return []byte(val), nil
 	}
 }


### PR DESCRIPTION
Athena data type values for which conversion to Go types is not supported are now returned as `[]byte`.