### PR TITLE
Stop converting date and time value to `time.Time`.

### DIFF
--- a/value.go
+++ b/value.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/athena"
 )
@@ -102,14 +101,8 @@ func convertValue(athenaType string, rawValue *string) (any, error) {
 		return strconv.ParseFloat(val, 32)
 	case "double", "decimal":
 		return strconv.ParseFloat(val, 64)
-	case "varchar":
+	case "varchar", "timestamp", "timestamp with time zone", "date":
 		return val, nil
-	case "timestamp":
-		return time.Parse(TimestampLayout, val)
-	case "timestamp with time zone":
-		return time.Parse(TimestampWithTimeZoneLayout, val)
-	case "date":
-		return time.Parse(DateLayout, val)
 	default:
 		return []byte(val), nil
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -2,7 +2,6 @@ package athena
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -10,14 +9,6 @@ import (
 func TestConvertValue(t *testing.T) {
 	toPtr := func(s string) *string {
 		return &s
-	}
-
-	parseTime := func(t *testing.T, layout, value string) time.Time {
-		parsed, err := time.Parse(layout, value)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return parsed
 	}
 
 	tests := map[string]struct {
@@ -83,17 +74,17 @@ func TestConvertValue(t *testing.T) {
 		"timestamp": {
 			athenaType: "timestamp",
 			rawValue:   toPtr("2023-01-15 12:34:56.789"),
-			want:       parseTime(t, TimestampLayout, "2023-01-15 12:34:56.789"),
+			want:       "2023-01-15 12:34:56.789",
 		},
 		"timestamp with time zone": {
 			athenaType: "timestamp with time zone",
 			rawValue:   toPtr("2023-01-15 12:34:56.789 JST"),
-			want:       parseTime(t, TimestampWithTimeZoneLayout, "2023-01-15 12:34:56.789 JST"),
+			want:       "2023-01-15 12:34:56.789 JST",
 		},
 		"date": {
 			athenaType: "date",
 			rawValue:   toPtr("2023-01-15"),
-			want:       parseTime(t, DateLayout, "2023-01-15"),
+			want:       "2023-01-15",
 		},
 		"unknown type": {
 			athenaType: "unknown",


### PR DESCRIPTION
SSIA